### PR TITLE
Refactor output file naming in script.py

### DIFF
--- a/script.py
+++ b/script.py
@@ -551,15 +551,10 @@ def output_modifier(string, state):
                     else:
                         cleaned_part = html.unescape(part.replace('< ', '').replace('<  ', '').replace('<  ', ''))
                         voice_to_use = params["narrator_voice"]
-                    # Check if character name exists and if not, just call it TTSOUT_
-                    if "character_menu" in state:
-                        output_file = Path(f'{params["output_folder_wav"]}/{state["character_menu"]}_{int(time.time())}_{i}.wav')
-                    else:
-                        output_file = Path(f'{params["output_folder_wav"]}/TTSOUT_{int(time.time())}_{i}.wav')
                     # Generate that TTS and output to a file
-                    output_file_str = output_file.as_posix()
+                    output_filename = get_output_filename(state)
                     generate_response = send_generate_request(
-                        cleaned_part, voice_to_use, language_code, output_file_str
+                        cleaned_part, voice_to_use, language_code, output_filename
                     )
                     audio_path = generate_response.get("data", {}).get("audio_path")
                     audio_files_paragraph.append(audio_path)
@@ -580,14 +575,9 @@ def output_modifier(string, state):
                 )
                 cleaned_part = html.unescape(processed_string)                
                 # Process the part and give it a non-character name if being used vai API or standalone.
-                if "character_menu" in state:
-                    output_file = Path(f'{params["output_folder_wav"]}/{state["character_menu"]}_{int(time.time())}.wav')
-                else:
-                    output_file = Path(f'{params["output_folder_wav"]}/TTSOUT_{int(time.time())}.wav')
-                output_file_str = output_file.as_posix()
-                output_file = get_output_filename(state)
+                output_filename = get_output_filename(state)
                 generate_response = send_generate_request(
-                    cleaned_part, params["voice"], language_code, output_file_str
+                    cleaned_part, params["voice"], language_code, output_filename
                 )
                 audio_path = generate_response.get("data", {}).get("audio_path")
                 final_output_file = audio_path
@@ -627,9 +617,11 @@ def output_modifier(string, state):
 
 
 def get_output_filename(state):
-    return Path(
-        f'{params["output_folder_wav"]}/{state["character_menu"]}_{str(uuid.uuid4())[:8]}.wav'
-    ).as_posix()
+    # Check if character name exists and if not, just call it TTSOUT_
+    if "character_menu" in state:
+        return Path(f'{params["output_folder_wav"]}/{state["character_menu"]}_{int(time.time())}.wav').as_posix()
+    else:
+        return Path(f'{params["output_folder_wav"]}/TTSOUT_{int(time.time())}.wav').as_posix()
 
 
 ###############################################


### PR DESCRIPTION
Hi!

I was sending an API call to Ooba, and found that I was getting a `KeyError: 'character_menu'` exception from `alltalk_tts`, which made the API return a 500:

![image](https://github.com/erew123/alltalk_tts/assets/25570327/6fb41854-5664-4534-8279-2f17e0d1bcbd)
_Cropped exception output here_

I tried updating the extension and ooba but the error persisted, so I thought I'd take a look at the code where it says it's being thrown and see what might be happening.

For context I'm just using instruct mode in Ooba. It seems like when that happens, maybe the `character_menu` property in `state` doesn't get set/exist, which is properly checked at line 583, but then when calling `get_output_filename(state)`, it then tries to access that property again without a check.

So I took a crack at fixing my problem (and doing a small refactor), and thought because of the nature of the issue, it could happen to others so I wanted to let you know via PR 😄 

I haven't familiarized myself with this repo 100% nor written any python code in my life so I'm not expecting this to get accepted, just wanted to put the info out there.

Thank you!