### PR TITLE
Feature: Add streaming TTS, using the new inference_stream() function from CoquiTTS

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <link rel="shortcut icon" href="#">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AllTalk TTS for Text generation webUI</title>
@@ -103,6 +104,12 @@
     }
 
     form {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    #outputFileContainer {
         display: flex;
         flex-direction: column;
         gap: 4px;
@@ -257,41 +264,95 @@
                 <option value="tr">Turkish</option>
             </select>
 
-            <label for="outputFile">Output File:</label>
-            <input type="text" id="outputFile" name="output_file" value="demo_output.wav" required>
+            <div id="outputFileContainer">
+                <label for="outputFile">Output File:</label>
+                <input type="text" id="outputFile" name="output_file" value="demo_output.wav" required>
+            </div>
 
+            <label for="streaming">Streaming:</label>
+            <select id="streaming" name="streaming" value="false" required>
+                <option value="false" selected>No</option>
+                <option value="true">Yes</option>
+            </select>
+            
             <!-- Audio player with autoplay -->
             <audio controls autoplay id="audioSource">
                 <source type="audio/wav" />
                 Your browser does not support the audio element.
             </audio>
+
             <span id="outputFilePath" style="height: 0px;">{{ output_file_path }}</span>
-            <button type="submit">Generate TTS</button>
+            <button id="submit" type="submit">
+                Generate TTS
+            </button>
         </form>
     </div>
 
     <script>
+        // Audio player
+        const audioPlayer = document.getElementById('audioSource');
+        function enableLoader(enable) {
+            // Change the submit button text and disable it while loading
+            const submit = document.getElementById('submit');
+            submit.disabled = enable ? true : false;
+            submit.style.opacity = enable ? 0.7 : 1.0;
+            submit.innerText = enable ? 'Generating...' : 'Generate TTS';
+            // Disable the audio player while loading
+            audioPlayer.disabled = enable ? true : false;
+            audioPlayer.style.opacity = enable ? 0.7 : 1.0;
+            audioPlayer.style.pointerEvents = enable ? 'none' : 'auto';
+        }
+        audioPlayer.addEventListener('canplay', () => {
+            enableLoader(false);
+            audioPlayer.play();
+        });
+        audioPlayer.addEventListener('abort', () => {
+            enableLoader(false);
+        });
+        audioPlayer.addEventListener('error', (e) => {
+            enableLoader(false);
+        });
+
+        // Streaming selector
+        const streaming = document.getElementById('streaming');
+        streaming.addEventListener('change', (event) => {
+            const outputFileContainer = document.getElementById('outputFileContainer');
+            if (event.target.value === 'true') {
+                outputFileContainer.style.display = 'none';
+            } else {
+                outputFileContainer.style.display = 'flex';
+            }
+        });
+        // Form submit
         const form = document.getElementById('ttsForm');
         form.addEventListener('submit', async (event) => {
             event.preventDefault();
 
+            enableLoader(true);
+            audioPlayer.pause();
+            
             const formData = new FormData(form);
-            const response = await fetch('/tts-demo-request', {
-                method: 'POST',
-                body: formData
-            });
+            if (formData.get('streaming') === 'true') {
+                const searchParams = new URLSearchParams(formData).toString();
+                audioPlayer.src = "/tts-demo-request?" + searchParams;
+                audioPlayer.load(); // Reload the audio player
+            } else {
+                const response = await fetch('/tts-demo-request', {
+                    method: 'POST',
+                    body: formData,
+                    cache: "no-store"
+                });
+            
+                // If not streaming, we just get the output file path
+                const result = await response.json();
 
-            const result = await response.json();
-
-            // Update the generated audio file path
-            const outputFilePath = document.getElementById('outputFilePath');
-            outputFilePath.textContent = result.output_file_path;
-
-            // Update the audio player source
-            const audioPlayer = document.getElementById('audioSource');
-            audioPlayer.src = `/audio/${result.output_file_path}`;
-            audioPlayer.load(); // Reload the audio player
-            audioPlayer.play(); // Play the audio;
+                // Update the generated audio file path
+                const outputFilePath = document.getElementById('outputFilePath');
+                outputFilePath.textContent = result.output_file_path;
+                // Update the audio player source
+                audioPlayer.src = `/audio/${result.output_file_path}`;
+                audioPlayer.load(); // Reload the audio player
+            }
         });
     </script>
     <p style="padding-left: 30px;"><a href="#toc">Back to top of page</a></p>


### PR DESCRIPTION
Generating TTS output through synchronous inference can take a long time if the input text is long. This PR introduces a streaming capability which allows the inference to happen in a streaming, chunked fashion. Inference itself is slightly slower, but the time to first audio is much faster for long passages.

Streaming inference was introduced in `tts` v0.20.0 via the `inference_stream()` function. This function returns a Python async generator which can conveniently be returned by FastAPI's `StreamingResponse` to the client. This PR calls the `model.inference_stream()` function with the same values currently sent to the synchronous `model.inference()` function, and adds a new endpoint which returns the ReadableStream result via `StreamingResponse`.

The demo app has also been changed to add a "Streaming" option in the Demo/Test TTS form.

This functionality only works for the code paths that currently call `model.inference()` from `tts` (which is to say, only XTTSv2 Local).

Relevant documentation:
* TTS/manual streaming: https://docs.coqui.ai/en/latest/models/xtts.html#streaming-manually
* FastAPI's `StreamingResponse`: https://fastapi.tiangolo.com/advanced/custom-response/#streamingresponse

**Performance**
(totally unscientific, especially given variation from model settings, but...)

On an RTX 2080 Ti:
* _Non-streaming_ generation of audio from a 2648-character text input began playing after **60.3sec**. 
* _Streaming_ generation of the same text took **82.12sec**, but audio playback began after **_3.78sec_**.

**Limitations**

Ideally, we could leverage a higher-level JS API to handle and play the streaming chunks as audio. The W3C `MediaStream` API is perfect for this, but unfortunately [it does not handle `audio/wav`](https://github.com/w3c/media-source/issues/55). Clients using the `alltalk_tts` API will need to manage the streaming chunks themselves. For the demo app, I setup a new `GET` route at `/tts-demo-request` which takes in the same form values that are `POST`ed in the non-streaming configuration. This endpoint streams the wav chunks directly, which can then be interpreted (like any other streaming URL) by the `<audio>` tag -- but the `audio` tag gives little control to developers.

Other implementations could include using the `AudioWorkletNode` API (an example is referenced in the link above, but it's messy) or doing live transcoding to mp3 in the backend.