### PR TITLE
Made compatible with older GPUs (1070)

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -110,7 +110,7 @@ def format_audio_list(target_language, whisper_model, out_path, eval_split_numbe
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
     print("[FINETUNE] Loading Whisper Model:", whisper_model)
-    asr_model = WhisperModel(whisper_model, device=device, compute_type="float16")
+    asr_model = WhisperModel(whisper_model, device=device, compute_type="float32")
 
     metadata = {"audio_file": [], "text": [], "speaker_name": []}
 


### PR DESCRIPTION
Description:
Summary
This pull request proposes changing the default compute type from float16 to float32 in the initialization of the Whisper model within the finetuning process. This adjustment aims to enhance compatibility across a wider range of hardware, especially for users whose devices do not support efficient float16 computation.

Background
While float16 computation can significantly speed up operations on GPUs that support it (notably, those with Tensor Cores like NVIDIA's Volta and newer architectures), not all users have access to such hardware. Attempting to run float16 computations on unsupported devices leads to a ValueError, indicating the device or backend does not support efficient float16 computation. This issue can hinder users from utilizing the finetuning functionality, limiting the accessibility and usability of the tool.

Proposed Change
File Affected: finetune.py
Change Detail: Update the compute type in the Whisper model initialization from compute_type="float16" to compute_type="float32".
Rationale
Compatibility: float32 is widely supported across various hardware and software setups, ensuring that more users can run the finetuning process without encountering compatibility issues.
Stability: Using float32 avoids the potential for errors related to unsupported float16 operations, making the finetuning process more robust across different environments.
Performance vs. Accessibility Trade-off: While acknowledging that float32 computations might be slower and more memory-intensive than float16 on supported hardware, this change prioritizes broader accessibility. It ensures that users without high-end GPUs can still benefit from the finetuning capabilities.
Impact on Users
Users with hardware that supports float16 may experience slower performance due to the higher precision and associated computational overhead of float32.
Users without float16-compatible hardware will gain the ability to use the finetuning feature without encountering the previously mentioned ValueError.
Conclusion
We propose this change as a means to increase the tool's accessibility and ease of use, ensuring that a broader user base can benefit from the finetuning functionality without being limited by hardware capabilities. What would be best is if it trys to do 16, and if that causes an error, then it falls back to 32. But I didnt code that. 