### PR TITLE
Tune docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ RUN apt-get update && apt-get upgrade -y \
     && ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /app
-COPY . .
 ENV CUDA_DOCKER_ARCH=all
+COPY system/requirements/requirements_docker.txt system/requirements/requirements_docker.txt
 RUN pip install --no-cache-dir --no-deps -r system/requirements/requirements_docker.txt && \
     pip install --no-cache-dir deepspeed
+COPY . .
 
 EXPOSE 7851 7852
 RUN chmod +x launch.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   alltalk-tts:
-    image: alltalk:v1-9c
+    image: ${IMAGE:-alltalk:v1-9c}
     restart: unless-stopped
     ports:
       - "7851:7851"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
       - ./voices:/app/voices/
       - ./finetune/put-voice-samples-in-here:/app/finetune/put-voice-samples-in-here
       - ./dockerconfig.json:/app/confignew.json
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:7851/api/ready"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
These commits update the docker configs to make it easier to work on the code locally. The main change that users will care about is the reordering of the dockerfile rules, reducing how much time it takes to test code updates that don't involve changing dependencies. The rest is just a little quality-of-life gravy.

I know there's a v2 coming, however I saw there's no dockerfile (yet). I figure you might be able to adapt this for v2 when alltalkbeta is merged to main.