### PR TITLE
Add distil-large-v3 for dataset creation

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -1609,7 +1609,7 @@ if __name__ == "__main__":
                             ("medium", "large"),
                             ("small", "large"),
                             ("distil-large-v3 (en only)", "distil-large-v3"),
-                            ("distil-large-v2 (en only)", "distil-large-v3"),
+                            ("distil-large-v2 (en only)", "distil-large-v2"),
                         ],
                         scale=1,
                     )

--- a/finetune.py
+++ b/finetune.py
@@ -1607,7 +1607,9 @@ if __name__ == "__main__":
                             "large-v2",
                             "large",
                             "medium",
-                            "small"
+                            "small",
+                            "distil-large-v3"
+                            "distil-large-v2"
                         ],
                         scale=1,
                     )
@@ -1722,7 +1724,7 @@ if __name__ == "__main__":
                     3. Provide at least 2 minutes of audio, preferably 5-10 minutes for better results.<br>
                     4. Maximum Audio Length will ensure the audio samples do not exceed the set value in seconds. The AI model can only process so much audio per audio sample, per epoch.<br>
                     5. Enter a unique Project Name if you wish to create a dedicated training folder. You will need to specify this name as you move through the interfaces and click the Refresh buttons where needed.<br>
-                    6. Select the Whisper model (large-v2 recommended for English use cases).<br>
+                    6. Select the Whisper model (distil-large-v3 recommended for English use cases).<br>
                     7. Choose your Dataset Language.<br>
                     8. Adjust the Evaluation Split percentage (default 15% is suitable for most cases).<br>
                     9. Optionally enable the BPE Tokenizer for custom tokenization, which can improve the model's ability to handle unique words, accents, or languages by creating a vocabulary tailored to your specific dataset. This is especially useful for non-standard speech patterns or languages with complex morphology.<br>

--- a/finetune.py
+++ b/finetune.py
@@ -1601,15 +1601,15 @@ if __name__ == "__main__":
                     )
                     whisper_model = gr.Dropdown(
                         label="Whisper Model",
-                        value="large-v2",
+                        value="distil-large-v3",
                         choices=[
-                            "large-v3",
-                            "large-v2",
-                            "large",
-                            "medium",
-                            "small",
-                            "distil-large-v3"
-                            "distil-large-v2"
+                            ("large-v3", "large-v3"),
+                            ("large-v2", "large-v2"),
+                            ("large", "large"),
+                            ("medium", "large"),
+                            ("small", "large"),
+                            ("distil-large-v3 (en only)", "distil-large-v3"),
+                            ("distil-large-v2 (en only)", "distil-large-v3"),
                         ],
                         scale=1,
                     )


### PR DESCRIPTION
Since we have the latest faster-whisper installed, we should allow the users to use distil-whisper. I have made this the default option, and changed the choice to stay "en only". 

When they say that its 6.3x faster than the base large models, they are not lying. Dataset prep speeds up significantly. There is really no downside.

https://huggingface.co/distil-whisper/distil-large-v3

