### PR TITLE
Fix optional fields in OpenAI API

### DIFF
--- a/script.py
+++ b/script.py
@@ -214,7 +214,7 @@ def run_firsttime_script():
         else:
             script_path = os.path.join(this_dir, 'system', 'config', 'firstrun.py')  # Default to Standalone if nothing matched.
 
-        subprocess.run(['python', script_path], check=True)
+        subprocess.run([sys.executable, script_path], check=True)
     except subprocess.CalledProcessError as e:
         print(f"Error occurred while running the script: {e}")
     except Exception as e:
@@ -356,7 +356,7 @@ if os.path.isfile("/.dockerenv") and 'google.colab' not in sys.modules:
     print(f"[{branding}TTS] Internal Gradio address: http://localhost:{params['gradio_port_number']}")
 
 # Start the subprocess (now unified for both Docker and non-Docker environments)
-process = subprocess.Popen(["python", script_path])
+process = subprocess.Popen([sys.executable, script_path])
 
 # Check if the subprocess has started successfully
 if process.poll() is None:
@@ -468,7 +468,7 @@ check_espeak_ng()
 def start_subprocess():
     global process
     if process is None or process.poll() is not None:
-        process = subprocess.Popen(["python", script_path])
+        process = subprocess.Popen([sys.executable, script_path])
         return "Subprocess started."
     else:
         return "Subprocess is already running."

--- a/tts_server.py
+++ b/tts_server.py
@@ -741,8 +741,8 @@ async def openai_tts_generate(request: Request):
         model = json_data["model"]  # Currently ignored
         input_text = json_data["input"]
         voice = json_data["voice"]
-        response_format = json_data["response_format"].lower()
-        speed = json_data["speed"]
+        response_format = json_data.get("response_format", "wav").lower()
+        speed = json_data.get("speed", 1.0)
         print(f"[{branding}Debug] Input text: {input_text}")  if debug_openai else None
         print(f"[{branding}Debug] Voice: {voice}")  if debug_openai else None
         print(f"[{branding}Debug] Speed: {speed}")  if debug_openai else None

--- a/tts_server.py
+++ b/tts_server.py
@@ -1594,7 +1594,7 @@ async def apifunction_trigger_analysis(threshold: int = Query(default=98)):
     env["PATH"] = os.path.join(venv_path, "bin") + ":" + env["PATH"]
     ttslist_path = this_dir / output_directory / "ttsList.json"
     wavfile_path = this_dir / output_directory
-    subprocess.run(["python", "tts_diff.py", f"--threshold={threshold}", f"--ttslistpath={ttslist_path}", f"--wavfilespath={wavfile_path}"], cwd=this_dir / "system" / "tts_diff", env=env)
+    subprocess.run([sys.executable, "tts_diff.py", f"--threshold={threshold}", f"--ttslistpath={ttslist_path}", f"--wavfilespath={wavfile_path}"], cwd=this_dir / "system" / "tts_diff", env=env)
     # Read the analysis summary
     try:
         with open(this_dir / output_directory / "analysis_summary.json", "r") as summary_file:
@@ -1613,7 +1613,7 @@ async def apifunction_srt_generation():
     env["PATH"] = os.path.join(venv_path, "bin") + ":" + env["PATH"]
     ttslist_path = this_dir / output_directory / "ttsList.json"
     wavfile_path = this_dir / output_directory
-    subprocess.run(["python", "tts_srt.py", f"--ttslistpath={ttslist_path}", f"--wavfilespath={wavfile_path}"], cwd=this_dir / "system" / "tts_srt", env=env)
+    subprocess.run([sys.executable, "tts_srt.py", f"--ttslistpath={ttslist_path}", f"--wavfilespath={wavfile_path}"], cwd=this_dir / "system" / "tts_srt", env=env)
     srt_file_path = this_dir / output_directory / "subtitles.srt"
     if not srt_file_path.exists():
         raise HTTPException(status_code=404, detail="Subtitle file not found.")


### PR DESCRIPTION
The optional fields response_format and speed in the OpenAI API (/v1/audio/speech) where causing a KeyError when omitted.

To test this, the example from the OpenAI docs can be used:
```shell
curl http://127.0.0.1:7851/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "model": "tts-1",
    "input": "The quick brown fox jumped over the lazy dog.",
    "voice": "alloy"
  }' \
  --output speech.mp3
```

Was causing:
```
[AllTalk Debug] Received JSON data: {'model': 'tts-1', 'input': 'The quick brown fox jumped over the lazy dog.', 'voice': 'alloy'}
[AllTalk Debug] An error occurred: 'response_format'
```

Additionally i changed "python" to sys.executable when the sub processes are spawned, which makes it possible to run it in a venv instead of conda.