### PR TITLE
Adding github action for CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,53 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python CI
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11.9
+        uses: actions/setup-python@v3
+        if: ${{ hashFiles('./test') != '' }}
+        with:
+          python-version: "3.11.9"
+      - name: Install dependencies
+        if: ${{ hashFiles('./test') != '' }}
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f system/requirements/requirements_unit_test.txt ]; then
+            pip install -r system/requirements/requirements_unit_test.txt;
+          fi
+      - name: Test with pytest
+        if: ${{ hashFiles('./test') != '' }}
+        run: |
+          pytest test --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+      - name: Surface failing tests
+        if: always()
+        uses: pmeier/pytest-results-action@v0.6.0
+        with:
+          # A list of JUnit XML files, directories containing the former, and wildcard
+          # patterns to process.
+          # See @actions/glob for supported patterns.
+          path: junit/test-results.xml
+
+          # (Optional) Add a summary of the results at the top of the report
+          summary: true
+
+          # (Optional) Select which results should be included in the report.
+          # Follows the same syntax as `pytest -r`
+          display-options: fEX
+
+          # (Optional) Fail the workflow if no JUnit XML was found.
+          fail-on-empty: false
+
+          # (Optional) Title of the test results section in the workflow summary
+          title: Test results

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/system/requirements/requirements_unit_test.txt
+++ b/system/requirements/requirements_unit_test.txt
@@ -1,0 +1,4 @@
+filelock>=3.16.1
+pydantic>=2.7.0
+pytest>=8.3.3
+pytest-cov>=6.0.0


### PR DESCRIPTION
The new github action runs unit tests and publishes a nice reports. More details:

- Runs on push and pull requests
- Execution time is only about 30s using a stripped down requirements file
  - Using `requirements_standalone.txt` would be possible, however this increases execution time to 5min due dependency downloads
- Skips most steps if there is no `test` folder

## Successful test run
![successful_tests](https://github.com/user-attachments/assets/07300f8b-cbb0-4f00-b81b-d8a60d6e978a)

## Failing test run
![failing_unit_tests](https://github.com/user-attachments/assets/4179ab99-f234-4362-8528-c18820aa262f)

# Out of scope
- Publishing a nice report also for test coverage (did not find a quick solution to this). Can be added later if needed.
- Linting of python code (would presumably take quite some time to satisfy the rules). Can be added later if needed.