### PR TITLE
Resolves "Create: command not found" error

### DIFF
--- a/atsetup.sh
+++ b/atsetup.sh
@@ -364,7 +364,7 @@ install_custom_standalone() {
     rm deepspeed-0.14.2+cu121torch2.2-cp311-cp311-manylinux_2_24_x86_64.whl
     pip install -r system/requirements/requirements_parler.txt
     conda clean --all --force-pkgs-dirs -y
-    Create start_environment.sh to run AllTalk
+    # Create start_environment.sh to run AllTalk
     cat << EOF > start_environment.sh
 #!/bin/bash
 cd "$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
Resolve error in `atsetup.sh`

> ./atsetup.sh: line 367: Create: command not found

This was just a comment that did not have a `#` in front of it.