### PR TITLE
AllTalkBeta: Docker Build: Fix conda build error logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY docker/conda/build/environment-*.yml environment.yml
 RUN <<EOR
     RESULT=$( { conda env create -f environment.yml ; } 2>&1 )
 
-    if echo $RESULT | grep -izq error ; then
+    if [ $? -ne 0 ] ; then
       echo "Failed to install conda dependencies: $RESULT"
       exit 1
     fi
@@ -129,9 +129,9 @@ COPY . .
 # Create script to execute firstrun.py and run it:
 ##############################################################################
 RUN echo $'#!/usr/bin/env bash \n\
-source ~/.bashrc \n\
-conda activate alltalk \n\
-python ./system/config/firstrun.py $@' > ./start_firstrun.sh
+  source ~/.bashrc \n\
+  conda activate alltalk \n\
+  python ./system/config/firstrun.py $@' > ./start_firstrun.sh
 
 RUN chmod +x start_firstrun.sh
 RUN ./start_firstrun.sh --tts_model $TTS_MODEL

--- a/docker/conda/Dockerfile
+++ b/docker/conda/Dockerfile
@@ -54,7 +54,7 @@ RUN <<EOR
       -c anaconda \
       -c nvidia ; } 2>&1 )
 
-    if echo $RESULT | grep -izq error ; then
+    if [ $? -ne 0 ] ; then
       echo "Failed to install conda dependencies: $RESULT"
       exit 1
     fi

--- a/docker/deepspeed/Dockerfile
+++ b/docker/deepspeed/Dockerfile
@@ -40,7 +40,7 @@ COPY build/environment-*.yml environment.yml
 RUN <<EOR
     RESULT=$( { conda env create -f environment.yml ; } 2>&1 )
 
-    if echo $RESULT | grep -izq error ; then
+    if [ $? -ne 0 ] ; then
       echo "Failed to install conda dependencies: $RESULT"
       exit 1
     fi


### PR DESCRIPTION
A package called `libgpg-error` is causing the logic in [conda dockerfile](/docker/conda/Dockerfile) to erroneously believe the conda install failed.

This PR changes the logic to look for the environment file created after a successful conda install. This file is a requirement for the next layer, so it's a logical check to ensure the build passes.

This PR additionally changes the same logic for both DeepSpeed and the root Dockerfile. One issue with DeepSpeed is that pytorch is no longer available via Conda, it *is* available through pip however. I will submit a separate PR for this.

Ref: https://github.com/erew123/alltalk_tts/issues/510