### PR TITLE
AllTalkBeta: Docker Build: Replace conda with pip for torch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY docker/conda/build/environment-*.yml environment.yml
 RUN <<EOR
     RESULT=$( { conda env create -f environment.yml ; } 2>&1 )
 
-    if echo $RESULT | grep -izq error ; then
+    if [ ! -f /environment-cu-${CUDA_VERSION}-cp-${PYTHON_VERSION}.yml] ; then
       echo "Failed to install conda dependencies: $RESULT"
       exit 1
     fi
@@ -129,9 +129,9 @@ COPY . .
 # Create script to execute firstrun.py and run it:
 ##############################################################################
 RUN echo $'#!/usr/bin/env bash \n\
-source ~/.bashrc \n\
-conda activate alltalk \n\
-python ./system/config/firstrun.py $@' > ./start_firstrun.sh
+  source ~/.bashrc \n\
+  conda activate alltalk \n\
+  python ./system/config/firstrun.py $@' > ./start_firstrun.sh
 
 RUN chmod +x start_firstrun.sh
 RUN ./start_firstrun.sh --tts_model $TTS_MODEL

--- a/docker/conda/Dockerfile
+++ b/docker/conda/Dockerfile
@@ -43,11 +43,14 @@ RUN <<EOR
       gxx_linux-64 \
       pytorch \
       pytorch-cuda=${CUDA_SHORT_VERSION} \
+      torchvision \
+      torchaudio \
       nvidia/label/cuda-${CUDA_SHORT_VERSION}.0::cuda-toolkit \
       faiss-gpu=1.9.0 \
       libaio \
       conda-forge::ffmpeg=7.1.0 \
       conda-forge::portaudio=19.7.0 \
+      -c pytorch
       -c anaconda \
       -c nvidia ; } 2>&1 )
 

--- a/docker/conda/Dockerfile
+++ b/docker/conda/Dockerfile
@@ -43,14 +43,11 @@ RUN <<EOR
       gxx_linux-64 \
       pytorch \
       pytorch-cuda=${CUDA_SHORT_VERSION} \
-      torchvision \
-      torchaudio \
-      libaio \
       nvidia/label/cuda-${CUDA_SHORT_VERSION}.0::cuda-toolkit \
       faiss-gpu=1.9.0 \
+      libaio \
       conda-forge::ffmpeg=7.1.0 \
       conda-forge::portaudio=19.7.0 \
-      -c pytorch \
       -c anaconda \
       -c nvidia ; } 2>&1 )
 

--- a/docker/conda/Dockerfile
+++ b/docker/conda/Dockerfile
@@ -54,7 +54,7 @@ RUN <<EOR
       -c anaconda \
       -c nvidia ; } 2>&1 )
 
-    if echo $RESULT | grep -izq error ; then
+    if [ ! -f /environment-cu-${CUDA_VERSION}-cp-${PYTHON_VERSION}.yml] ; then
       echo "Failed to install conda dependencies: $RESULT"
       exit 1
     fi

--- a/docker/deepspeed/Dockerfile
+++ b/docker/deepspeed/Dockerfile
@@ -40,7 +40,7 @@ COPY build/environment-*.yml environment.yml
 RUN <<EOR
     RESULT=$( { conda env create -f environment.yml ; } 2>&1 )
 
-    if echo $RESULT | grep -izq error ; then
+    if [ ! -f /environment-cu-${CUDA_VERSION}-cp-${PYTHON_VERSION}.yml] ; then
       echo "Failed to install conda dependencies: $RESULT"
       exit 1
     fi

--- a/docker/deepspeed/Dockerfile
+++ b/docker/deepspeed/Dockerfile
@@ -57,7 +57,11 @@ RUN <<EOR
 
   pip install \
       deepspeed-kernels \
-      scikit-learn
+      scikit-learn \
+      torch \
+      torchvision \
+      torchaudio \
+      libaio
 EOR
 
 


### PR DESCRIPTION
The DeepSpeed container was failing to build, due to a lack of pyTorch/Torch being available. Torch has pulled their packages from Conda for reasons not explored here.

This PR updates the Conda environment to reflect that and moves package installation to pip stage.

Opinion/Discussion:
Unless I'm missing a project scope or context, using Conda doesn't yield useful cross-platform support since we're basing off a linux image. This docker image will only exist in a Linux environment in the container regardless of the host.