### PR TITLE
Refactoring docker images, updating CUDA to 12.6 and pytorch 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,5 +173,4 @@ cython_debug/
 .idea/*
 
 # Docker build
-docker/conda/build
 docker/deepspeed/build

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -36,7 +36,7 @@ The Docker image currently works on Windows and Linux, optionally supporting NVI
 4. Download CUDA toolkit keyring: `wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-keyring_1.1-1_all.deb`
 5. Install keyring: `sudo dpkg -i cuda-keyring_1.1-1_all.deb`
 6. Update package list: `sudo apt-get update`
-7. Install CUDA toolkit: `sudo apt-get -y install cuda-toolkit-12-4`
+7. Install CUDA toolkit: `sudo apt-get -y install cuda-toolkit-12-6`
 8. Install Docker Desktop using WSL2 as the backend
 9. Restart
 10. If you wish to monitor the terminal remotely via SSH, follow [this guide](https://www.hanselman.com/blog/how-to-ssh-into-wsl2-on-windows-10-from-an-external-machine).

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -29,6 +29,12 @@ while [ "$#" -gt 0 ]; do
       DOCKER_TAG="$2"
       shift
       ;;
+    --github-repository)
+      if [ -n "${GITHUB_REPOSITORY}" ] && ! [[ $GITHUB_REPOSITORY =~ ^--.* ]]; then
+        GITHUB_REPOSITORY="$2"
+        shift
+      fi
+      ;;
     *)
       # Allow to pass arbitrary arguments to docker as well to be flexible:
       ADDITIONAL_ARGS+=( $1 )
@@ -65,4 +71,4 @@ docker run \
   --name alltalk \
  "${DOCKER_ARGS[@]}" \
  "${ADDITIONAL_ARGS[@]}" \
-  alltalk_beta:${DOCKER_TAG} &> /dev/stdout
+  ${GITHUB_REPOSITORY}alltalk_beta:${DOCKER_TAG} &> /dev/stdout

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3:24.7.1-0 AS build
 
-ARG CUDA_VERSION=12.4.1
+ARG CUDA_VERSION=12.6.0
 ENV CUDA_VERSION=$CUDA_VERSION
 
 ARG PYTHON_VERSION=3.11.11
@@ -13,6 +13,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV CUDA_DOCKER_ARCH=all
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV CONDA_AUTO_UPDATE_CONDA="false"
+
+ENV ALLTALK_DIR=/opt/alltalk
 
 ##############################################################################
 # Installation/Basic Utilities
@@ -35,24 +37,24 @@ EOR
 ##############################################################################
 RUN <<EOR
     CUDA_SHORT_VERSION=${CUDA_VERSION%.*}
-
     conda create -y -n "alltalk" -c conda-forge python=${PYTHON_VERSION}
     conda activate alltalk
-    RESULT=$( { conda install -y \
+    conda install -y \
       gcc_linux-64 \
       gxx_linux-64 \
-      pytorch \
-      pytorch-cuda=${CUDA_SHORT_VERSION} \
-      torchvision \
-      torchaudio \
       libaio \
-      nvidia/label/cuda-${CUDA_SHORT_VERSION}.0::cuda-toolkit \
       faiss-gpu=1.9.0 \
+      cuda=${CUDA_VERSION} cuda-tools=${CUDA_VERSION} cuda-toolkit=${CUDA_VERSION} cuda-version=${CUDA_SHORT_VERSION} \
+      cuda-command-line-tools=${CUDA_VERSION} cuda-compiler=${CUDA_VERSION} cuda-runtime=${CUDA_VERSION} \
+      cuda-libraries=${CUDA_VERSION} cuda-libraries-dev=${CUDA_VERSION} cuda-libraries-static=${CUDA_VERSION} \
+      cuda-cudart=${CUDA_SHORT_VERSION} cuda-cudart_linux-64=${CUDA_SHORT_VERSION} \
+      cudnn=9.3 \
+      py-cpuinfo=9 \
       conda-forge::ffmpeg=7.1.0 \
       conda-forge::portaudio=19.7.0 \
       -c pytorch \
-      -c anaconda \
-      -c nvidia ; } 2>&1 )
+      -c nvidia \
+      -c anaconda
 
     if [ $? -ne 0 ] ; then
       echo "Failed to install conda dependencies: $RESULT"
@@ -62,16 +64,17 @@ RUN <<EOR
     conda clean -a && pip cache purge
 EOR
 
-##############################################################################
-# Export conda environment:
-##############################################################################
 RUN <<EOR
-  conda activate alltalk
-  conda env export > /environment-cu-${CUDA_VERSION}-cp-${PYTHON_VERSION}.yml
-EOR
+  CUDA_SHORT_VERSION=${CUDA_VERSION%.*}
+  CUDA_SHORT_VERSION_NO_DOT=${CUDA_SHORT_VERSION//./}
 
-##############################################################################
-# Make environment file available to docker build output:
-##############################################################################
-FROM scratch
-COPY --from=build /environment-*.yml /
+  conda activate alltalk
+  mkdir -p ${ALLTALK_DIR}/pip_cache
+  pip install --no-cache-dir --cache-dir=${ALLTALK_DIR}/pip_cache \
+      torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu${CUDA_SHORT_VERSION_NO_DOT}
+
+  if [ $? -ne 0 ] ; then
+    echo "Failed to install pip dependencies: $RESULT"
+    exit 1
+  fi
+EOR

--- a/docker/deepspeed/Dockerfile
+++ b/docker/deepspeed/Dockerfile
@@ -1,52 +1,14 @@
-FROM continuumio/miniconda3:24.7.1-0
+ARG GITHUB_REPOSITORY
+FROM ${GITHUB_REPOSITORY}alltalk_environment:latest
 
-ARG DEEPSPEED_VERSION=0.16.2
+ARG DEEPSPEED_VERSION=0.16.3
 ENV DEEPSPEED_VERSION=$DEEPSPEED_VERSION
-
-SHELL ["/bin/bash", "-l", "-c"]
-ENV SHELL=/bin/bash
-ENV HOST=0.0.0.0
-ENV DEBIAN_FRONTEND=noninteractive
-ENV CUDA_DOCKER_ARCH=all
-ENV NVIDIA_VISIBLE_DEVICES=all
-ENV CONDA_AUTO_UPDATE_CONDA="false"
 
 ##############################################################################
 # Directories:
 ##############################################################################
 ENV STAGE_DIR=/tmp
 RUN mkdir -p ${STAGE_DIR}
-
-##############################################################################
-# Installation/Basic Utilities
-##############################################################################
-RUN <<EOR
-  apt-get update
-  apt-get upgrade -y
-  apt-get install --no-install-recommends -y \
-      espeak-ng \
-      curl \
-      wget \
-      jq \
-      vim
-
-   apt-get clean && rm -rf /var/lib/apt/lists/*
-EOR
-
-##############################################################################
-# Create a conda environment and install dependencies:
-##############################################################################
-COPY build/environment-*.yml environment.yml
-RUN <<EOR
-    RESULT=$( { conda env create -f environment.yml ; } 2>&1 )
-
-    if [ $? -ne 0 ] ; then
-      echo "Failed to install conda dependencies: $RESULT"
-      exit 1
-    fi
-
-    conda clean -a && pip cache purge
-EOR
 
 ##############################################################################
 # Install python dependencies
@@ -56,8 +18,7 @@ RUN <<EOR
   conda activate alltalk
 
   pip install \
-      deepspeed-kernels \
-      scikit-learn
+      deepspeed-kernels
 EOR
 
 
@@ -69,6 +30,15 @@ RUN <<EOR
   cd ${STAGE_DIR}/DeepSpeed
   git checkout .
   git checkout "tags/v${DEEPSPEED_VERSION}" -b "v${DEEPSPEED_VERSION}"
+
+  # Patching some files due to bug https://github.com/microsoft/DeepSpeed/issues/6709
+  START_LINE=`awk '/#ifndef BF16_AVAILABLE/{ print NR; exit }' csrc/transformer/inference/csrc/gelu.cu`
+  TO_LINE=$((START_LINE + 2))
+  sed -i "${START_LINE},${TO_LINE}d" ./csrc/transformer/inference/csrc/gelu.cu
+
+  START_LINE=`awk '/#ifndef BF16_AVAILABLE/{ print NR; exit }' csrc/transformer/inference/csrc/transform.cu`
+  TO_LINE=$((START_LINE + 2))
+  sed -i "${START_LINE},${TO_LINE}d" ./csrc/transformer/inference/csrc/transform.cu
 EOR
 
 ##############################################################################

--- a/docker/variables.sh
+++ b/docker/variables.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-export CUDA_VERSION=12.4.1
+export CUDA_VERSION=12.6.0
 export PYTHON_VERSION=3.11.11
 export DEEPSPEED_VERSION=0.16.2
 export ALLTALK_DIR=/opt/alltalk
+export GITHUB_REPOSITORY=

--- a/system/tts_engines/rvc/lib/utils.py
+++ b/system/tts_engines/rvc/lib/utils.py
@@ -2,6 +2,8 @@ import numpy as np
 import re
 import unicodedata
 from fairseq import checkpoint_utils
+from fairseq.data import Dictionary
+import torch
 
 import logging
 
@@ -66,6 +68,7 @@ def load_embedding(embedder_model):
         #print("MODEL PATH IS", model_path)
         
         # Load model ensemble and task
+        torch.serialization.add_safe_globals([Dictionary])
         models = checkpoint_utils.load_model_ensemble_and_task(
             [f"{model_path}"],
             suffix="",


### PR DESCRIPTION
The following changes were made:

- Dropping the idea of having a Conda docker image producing an environment.yml for the Conda environments of the other 2 images. Now, it's a base image installing all the important dependencies used by the other images. This a) speeds up the build process in general and b) is a preparation for building the image with Github Actions.
- Update from CUDA 12.4 to CUDA 12.6
- Update to pytorch 2.6, now using pip instead of Conda because Conda is no longer supported