### PR TITLE
Add api output folder option

### DIFF
--- a/config.py
+++ b/config.py
@@ -70,6 +70,7 @@ class AlltalkConfigApiDef(BaseModel):
     api_narrator_enabled: str = "false"
     api_text_not_inside: str = "character"
     api_language: str = "en"
+    api_output_folder: str = ""
     api_output_file_name: str = "myoutputfile"
     api_output_file_timestamp: bool = True
     api_autoplay: bool = False

--- a/confignew.json
+++ b/confignew.json
@@ -59,6 +59,7 @@
         "api_narrator_enabled": "false",
         "api_text_not_inside": "character",
         "api_language": "en",
+        "api_output_folder": "",
         "api_output_file_name": "myoutputfile",
         "api_output_file_timestamp": true,
         "api_autoplay": false,

--- a/tts_server.py
+++ b/tts_server.py
@@ -1470,9 +1470,14 @@ def combine(output_folder, output_file_timestamp, output_file_name, audio_files,
 
 
         if output_folder == "":
-            output_file_path = this_dir / config.get_output_directory() / filename
+            output_file_path = os.path.join(this_dir / config.get_output_directory() / filename)
         else:
-            output_file_path = output_folder / filename
+            output_path = Path(output_folder)
+            if not os.path.exists(output_path):
+                os.makedirs(output_path)
+            output_file_path = os.path.join(output_path / filename)
+            
+            
         sf.write(output_file_path, audio, target_sample_rate)
 
         # Generate URLs based on API configuration
@@ -1858,7 +1863,10 @@ async def tts_handle_output_paths(output_file_name: str, output_folder: str, tim
     if output_folder == "":
         output_path = this_dir / config.get_output_directory() / filename
     else:
-        output_path = output_folder / filename
+        output_path = Path(output_folder)
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+        output_path = Path(output_folder) / filename
 
     if config.api_def.api_use_legacy_api:
         base_url = f'http://{config.api_def.api_legacy_ip_address}:{config.api_def.api_port_number}'


### PR DESCRIPTION
Create a new config variable api_output_folder to give users the ability to specifiy the output folder while generating per api 

Made for discussion [https://github.com/erew123/alltalk_tts/discussions/521](https://github.com/erew123/alltalk_tts/discussions/521)