### PR TITLE
Introduce ENV variables for Docker

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -53,7 +53,7 @@ following optional arguments:
     - Example: `docker-start.sh --voices /my/voices/dir`
 - `--rvc-voices` similar to voices, this option lets you pick the folder containing the [RVC models](https://github.com/erew123/alltalk_tts/wiki/RVC-(Retrieval%E2%80%90based-Voice-Conversion)).
     - Example: `docker-start.sh --rvc_voices /my/rvc/voices/dir`
-- `--no-ui` allows you to not expose port 7852 for the gradio interface and sets `launch_gradio` to `false`.
+- `--no-ui` allows you to not expose port 7852 for the gradio interface and sets `launch_gradio` and `gradio_interface` to `false`.
 - `--with-multi-engine-manager` enables the use of the [multi engine manager (MEM)](https://github.com/erew123/alltalk_tts/wiki/Multi-Engine-Manager)
     which allows for more parallel requests. By default, one TTS engine is started. Optionally, you can pass the
     file path of a JSON file which can be a subset of `mem_config.json` with more fine-grained configuration options.
@@ -66,8 +66,27 @@ following optional arguments:
 - Since the above commands only address the most important options, you might pass additional arbitrary docker arguments
   to the `docker-start.sh`.
 
-Of course, like any other Docker image, you can also directly use `docker run` directly and use `docker-start.sh` 
-as an inspiration.
+Of course, like for any other Docker image, you can also directly use `docker run` directly and use 
+[docker-start.sh](https://github.com/erew123/alltalk_tts/blob/alltalkbeta/docker-start.sh) as an inspiration.
+
+### Using environment variables for setting config values
+Instead of using config JSON files, there are config settings that can be directly set using environment (ENV) variables 
+when starting the application. This is also what is used internally in `docker-start.sh`.
+
+Since `docker-start.sh` allows to pass arbitrary params, it can also be used to set env variables, e.g:
+
+```
+./docker-start.sh -e ALLTALK_BRANDING="My Brand " -e ALLTALK_API_PORT_NUMBER=9876
+```
+
+or when using Docker directly:
+```
+docker run -e ALLTALK_BRANDING="My Brand " -e ALLTALK_API_PORT_NUMBER=9876 ...
+```
+
+Consult [docker_default_confignew.json](https://github.com/erew123/alltalk_tts/blob/alltalkbeta/docker_default_confignew.json) 
+and [docker_default_mem_config.json](https://github.com/erew123/alltalk_tts/blob/alltalkbeta/docker_default_mem_config.json) 
+for a list of all available env variables.
 
 
 ## Building your own images (advanced)

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -3,8 +3,8 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${SCRIPT_DIR=}/docker/variables.sh
 
-WITH_UI=true
-ENABLE_MULTI_ENGINE_MANAGER=false
+ALLTALK_GRADIO_INTERFACE=true
+ALLTALK_ENABLE_MULTI_ENGINE_MANAGER=false
 MULTI_ENGINE_MANAGER_CONFIG=
 DOCKER_TAG=latest-xtts
 DOCKER_REPOSITORY=erew123
@@ -26,10 +26,10 @@ while [ "$#" -gt 0 ]; do
       shift
       ;;
     --no-ui)
-      WITH_UI=false
+      ALLTALK_GRADIO_INTERFACE=false
       ;;
     --with-multi-engine-manager)
-      ENABLE_MULTI_ENGINE_MANAGER=true
+      ALLTALK_ENABLE_MULTI_ENGINE_MANAGER=true
       if [ -n "$2" ] && ! [[ $2 =~ ^--.* ]]; then
         MULTI_ENGINE_MANAGER_CONFIG=$2
         shift
@@ -74,8 +74,8 @@ if [[ -n $RVC_VOICES ]]; then
   DOCKER_ARGS+=( -v ${RVC_VOICES}:${ALLTALK_DIR}/models/rvc_voices )
 fi
 
-if [ "$WITH_UI" = true ] ; then
-    if [ "$ENABLE_MULTI_ENGINE_MANAGER" = true ] ; then
+if [ "ALLTALK_GRADIO_INTERFACE" = true ] ; then
+    if [ "$ALLTALK_ENABLE_MULTI_ENGINE_MANAGER" = true ] ; then
       DOCKER_ARGS+=( -p 7500:7500 )
     else
       DOCKER_ARGS+=( -p 7852:7852 )
@@ -87,8 +87,10 @@ if [[ -n $MULTI_ENGINE_MANAGER_CONFIG ]]; then
 fi
 
 # Pass env variables:
-DOCKER_ARGS+=( -e ENABLE_MULTI_ENGINE_MANAGER=${ENABLE_MULTI_ENGINE_MANAGER} )
-DOCKER_ARGS+=( -e WITH_UI=${WITH_UI} )
+DOCKER_ARGS+=( -e ALLTALK_ENABLE_MULTI_ENGINE_MANAGER=${ALLTALK_ENABLE_MULTI_ENGINE_MANAGER} )
+DOCKER_ARGS+=( -e ALLTALK_GRADIO_INTERFACE=${ALLTALK_GRADIO_INTERFACE} )
+DOCKER_ARGS+=( -e ALLTALK_LAUNCH_GRADIO=${ALLTALK_GRADIO_INTERFACE} )
+
 
 docker run \
   --rm \

--- a/docker_default_config.json
+++ b/docker_default_config.json
@@ -1,7 +1,0 @@
-{
-  "delete_output_wavs": "1",
-  "rvc_settings": {
-    "rvc_enabled": true,
-    "f0method": "rmvpe"
-  }
-}

--- a/docker_default_confignew.json
+++ b/docker_default_confignew.json
@@ -1,0 +1,40 @@
+{
+  "branding": $ENV.ALLTALK_BRANDING,
+  "delete_output_wavs": $ENV.ALLTALK_DELETE_OUTPUT_WAVS,
+  "gradio_interface": $ENV.ALLTALK_GRADIO_INTERFACE,
+  "output_folder": $ENV.ALLTALK_OUTPUT_FOLDER,
+  "gradio_port_number": $ENV.ALLTALK_GRADIO_PORT_NUMBER,
+  "launch_gradio": $ENV.ALLTALK_LAUNCH_GRADIO,
+  "transcode_audio_format": $ENV.ALLTALK_TRANSCODE_AUDIO_FORMAT,
+  "rvc_settings": {
+    "rvc_enabled": $ENV.ALLTALK_RVC_ENABLED,
+    "rvc_char_model_file": $ENV.ALLTALK_RVC_CHAR_MODEL_FILE,
+    "rvc_narr_model_file": $ENV.ALLTALK_RVC_NARR_MODEL_FILE,
+    "split_audio": $ENV.ALLTALK_RVC_SPLIT_AUDIO,
+    "autotune": $ENV.ALLTALK_RVC_AUTOTUNE,
+    "pitch": $ENV.ALLTALK_RVC_PITCH,
+    "filter_radius": $ENV.ALLTALK_RVC_FILTER_RADIUS,
+    "index_rate": $ENV.ALLTALK_RVC_INDEX_RATE,
+    "rms_mix_rate": $ENV.ALLTALK_RVC_RMS_MIX_RATE,
+    "protect": $ENV.ALLTALK_RVC_PROTECT,
+    "hop_length": $ENV.ALLTALK_RVC_HOP_LENGTH,
+    "f0method": $ENV.ALLTALK_RVC_F0METHOD,
+    "embedder_model": $ENV.ALLTALK_RVC_EMBEDDER_MODEL,
+    "training_data_size": $ENV.ALLTALK_RVC_TRAINING_DATA_SIZE
+  },
+  "api_def": {
+    "api_port_number": $ENV.ALLTALK_API_PORT_NUMBER,
+    "api_allowed_filter": $ENV.ALLTALK_API_ALLOWED_FILTER,
+    "api_length_stripping": $ENV.ALLTALK_API_LENGTH_STRIPPING,
+    "api_max_characters": $ENV.ALLTALK_API_MAX_CHARACTERS,
+    "api_use_legacy_api": $ENV.ALLTALK_API_USE_LEGACY_API,
+    "api_text_filtering": $ENV.ALLTALK_API_TEXT_FILTERING,
+    "api_narrator_enabled": $ENV.ALLTALK_API_NARRATOR_ENABLED,
+    "api_text_not_inside": $ENV.ALLTALK_API_TEXT_NOT_INSIDE,
+    "api_language": $ENV.ALLTALK_API_LANGUAGE,
+    "api_output_file_name": $ENV.ALLTALK_API_OUTPUT_FILE_NAME,
+    "api_output_file_timestamp": $ENV.ALLTALK_API_OUTPUT_FILE_TIMESTAMP,
+    "api_autoplay": $ENV.ALLTALK_API_AUTOPLAY,
+    "api_autoplay_volume": $ENV.ALLTALK_API_AUTOPLAY_VOLUME
+  }
+}

--- a/docker_default_mem_config.json
+++ b/docker_default_mem_config.json
@@ -1,3 +1,18 @@
 {
-  "auto_start_engines": 1
+  "base_port": $ENV.ALLTALK_MEM_BASE_PORT,
+  "api_server_port": $ENV.ALLTALK_MEM_API_SERVER_PORT,
+  "auto_start_engines": $ENV.ALLTALK_MEM_AUTO_START_ENGINES,
+  "max_instances": $ENV.ALLTALK_MEM_MAX_INSTANCES,
+  "gradio_interface_port": $ENV.ALLTALK_MEM_GRADIO_INTERFACE_PORT,
+  "max_retries": $ENV.ALLTALK_MEM_MAX_RETRIES,
+  "initial_wait": $ENV.ALLTALK_MEM_INITIAL_WAIT,
+  "backoff_factor": $ENV.ALLTALK_MEM_BACKOFF_FACTOR,
+  "debug_mode": $ENV.ALLTALK_MEM_DEBUG_MODE,
+  "max_queue_time": $ENV.ALLTALK_MEM_MAX_QUEUE_TIME,
+  "queue_check_interval": $ENV.ALLTALK_MEM_QUEUE_CHECK_INTERVAL,
+  "tts_request_timeout": $ENV.ALLTALK_MEM_TTS_REQUEST_TIMEOUT,
+  "text_length_factor": $ENV.ALLTALK_MEM_TEXT_LENGTH_FACTOR,
+  "concurrent_request_factor": $ENV.ALLTALK_MEM_CONCURRENT_REQUEST_FACTOR,
+  "diminishing_factor": $ENV.ALLTALK_MEM_DIMINISHING_FACTOR,
+  "queue_position_factor": $ENV.ALLTALK_MEM_QUEUE_POSITION_FACTOR
 }

--- a/tts_mem.py
+++ b/tts_mem.py
@@ -55,7 +55,7 @@ from collections import deque
 from datetime import datetime, timedelta
 from requests.exceptions import RequestException
 from werkzeug.serving import make_server, WSGIRequestHandler
-from config import AlltalkMultiEngineManagerConfig
+from config import AlltalkMultiEngineManagerConfig, AlltalkConfig
 from flask_cors import CORS, cross_origin
 from flask import Flask, request, jsonify, send_from_directory, send_file
 
@@ -76,7 +76,6 @@ should_exit = threading.Event()
 # Global variable to hold the monitor thread
 stop_monitor = threading.Event()
 monitor = None
-WITH_UI = os.getenv("WITH_UI", True).lower() == 'true'
 
 flask_app = Flask(__name__)
 CORS(flask_app)
@@ -84,6 +83,7 @@ flask_app.config['OUTPUT_FOLDER'] = str(Path(os.getcwd()) / 'outputs')
 
 # Load configuration at the start of the script
 config = AlltalkMultiEngineManagerConfig.get_instance()
+USE_GRADIO = AlltalkConfig.get_instance().gradio_interface
 
 def signal_handler(signum, frame):
     print("[AllTalk MEM] Interrupt received, shutting down...")
@@ -125,7 +125,7 @@ print(f"[AllTalk MEM] \033[93m     MEM is not intended for production use and\03
 print(f"[AllTalk MEM] \033[93m      there is NO support being offered on MEM\033[00m")
 print(f"[AllTalk MEM]")
 print(f"[AllTalk MEM] \033[94mAPI/Queue   :\033[00m \033[92mhttp://127.0.0.1:{config.api_server_port}/api/tts-generate\033[00m")
-if WITH_UI:
+if USE_GRADIO:
     print(f"[AllTalk MEM] \033[94mGradio Light:\033[00m \033[92mhttp://127.0.0.1:{config.gradio_interface_port}\033[00m")
     print(f"[AllTalk MEM] \033[94mGradio Dark :\033[00m \033[92mhttp://127.0.0.1:{config.gradio_interface_port}?__theme=dark\033[00m")
 print(f"[AllTalk MEM]")
@@ -1492,7 +1492,7 @@ def auto_start_engines():
 # Main execution
 if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal_handler)
-    if WITH_UI:
+    if USE_GRADIO:
         print("[AllTalk MEM] Starting gradio...")
         interface = create_gradio_interface()
         # Start the Gradio interface


### PR DESCRIPTION
TL;DR: Using Docker, it may be preferable to set config values via ENV variables instead of JSON files, especially if you only want to change a few of them.

Instead of using config JSON files, there are config settings that can be directly set using environment (ENV) variables 
when starting the application. This is also what is used internally in `docker-start.sh`.

Since `docker-start.sh` allows to pass arbitrary params, it can also be used to set env variables, e.g:

```
./docker-start.sh -e ALLTALK_BRANDING="My Brand " -e ALLTALK_API_PORT_NUMBER=9876
```

or when using Docker directly:
```
docker run -e ALLTALK_BRANDING="My Brand " -e ALLTALK_API_PORT_NUMBER=9876 ...
```

There are env variables for the most important settings, but not for all.