### PR TITLE
maxsize 3 for LRU cache for RVC

### DIFF
--- a/system/tts_engines/rvc/infer/infer.py
+++ b/system/tts_engines/rvc/infer/infer.py
@@ -171,7 +171,7 @@ def voice_conversion(
         return None, None
 
 
-@lru_cache
+@lru_cache(maxsize=3)
 def get_vc(weight_root, sid, file_index=None, training_data_size=10000, debug_rvc=False):
     net_g = None
     branding="AllTalk "


### PR DESCRIPTION
Feature was introduced in https://github.com/erew123/alltalk_tts/pull/383 but without maxsize, which meant rvc models would never get unloaded