### PR TITLE
Provide config setting for RVC model cache size

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,6 +38,7 @@ class AlltalkConfigRvcSettings(BaseModel):
     f0method: str = "fcpe"
     embedder_model: str = "hubert"
     training_data_size: int = 45000
+    model_cache_size: int = 1
 
 class AlltalkConfigTgwUi(BaseModel):
     tgwui_activate_tts: bool = True

--- a/confignew.json
+++ b/confignew.json
@@ -26,7 +26,8 @@
         "hop_length": 130,
         "f0method": "fcpe",
         "embedder_model": "hubert",
-        "training_data_size": 45000
+        "training_data_size": 45000,
+        "model_cache_size": 1
     },
     "tgwui": {
         "tgwui_activate_tts": true,

--- a/docker_default_confignew.json
+++ b/docker_default_confignew.json
@@ -20,7 +20,8 @@
     "hop_length": $ENV.ALLTALK_RVC_HOP_LENGTH,
     "f0method": $ENV.ALLTALK_RVC_F0METHOD,
     "embedder_model": $ENV.ALLTALK_RVC_EMBEDDER_MODEL,
-    "training_data_size": $ENV.ALLTALK_RVC_TRAINING_DATA_SIZE
+    "training_data_size": $ENV.ALLTALK_RVC_TRAINING_DATA_SIZE,
+    "model_cache_size": $ENV.ALLTALK_RVC_MODEL_CACHE_SIZE
   },
   "api_def": {
     "api_port_number": $ENV.ALLTALK_API_PORT_NUMBER,

--- a/system/tts_engines/rvc/infer/infer.py
+++ b/system/tts_engines/rvc/infer/infer.py
@@ -9,6 +9,8 @@ import soundfile as sf
 import librosa
 from functools import lru_cache
 
+from config import AlltalkConfig
+
 now_dir = os.getcwd()
 sys.path.append(now_dir)
 
@@ -171,7 +173,7 @@ def voice_conversion(
         return None, None
 
 
-@lru_cache(maxsize=3)
+@lru_cache(maxsize=AlltalkConfig.get_instance().rvc_settings.model_cache_size)
 def get_vc(weight_root, sid, file_index=None, training_data_size=10000, debug_rvc=False):
     net_g = None
     branding="AllTalk "


### PR DESCRIPTION
Add setting `model_cache_size` (defaults to 1) to `confignew.json` plus env variable `ALLTALK_RVC_MODEL_CACHE_SIZE` for docker.