### PR TITLE
Pin pydantic due to bug in 2.11

### DIFF
--- a/system/requirements/requirements_colab.txt
+++ b/system/requirements/requirements_colab.txt
@@ -10,7 +10,7 @@ Jinja2>=3.1.0
 librosa>=0.10.2.post1
 local_attention==1.9.10
 onnxruntime-gpu>=1.18.0
-pydantic>=2.7.0
+pydantic==2.10.6
 python-Levenshtein>=0.25.1
 praat-parselmouth>=0.4.0
 pyworld>=0.3.0

--- a/system/requirements/requirements_standalone.txt
+++ b/system/requirements/requirements_standalone.txt
@@ -12,7 +12,7 @@ librosa>=0.10.2.post1
 local_attention==1.9.10
 openai-whisper
 onnxruntime-gpu>=1.18.1
-pydantic>=2.8.2
+pydantic==2.10.6
 python-Levenshtein>=0.25.1
 praat-parselmouth>=0.4.4
 pyworld>=0.3.4

--- a/system/requirements/requirements_textgen.txt
+++ b/system/requirements/requirements_textgen.txt
@@ -9,7 +9,7 @@ librosa>=0.10.2.post1
 local_attention>=1.9.0
 onnxruntime-gpu>=1.18.0
 openai-whisper
-pydantic>=2.7.0
+pydantic==2.10.6
 python-Levenshtein>=0.25.1
 praat-parselmouth>=0.4.0
 pyworld>=0.3.0

--- a/system/requirements/requirements_unit_test.txt
+++ b/system/requirements/requirements_unit_test.txt
@@ -1,4 +1,4 @@
 filelock>=3.16.1
-pydantic>=2.7.0
+pydantic==2.10.6
 pytest>=8.3.3
 pytest-cov>=6.0.0


### PR DESCRIPTION
A clean install of alltalk v2 gives error `TypeError: argument of type 'bool' is not iterable`. This seems to be a bug in pydantic, and the fix hasn't made it into a 2.11 release yet: https://github.com/pydantic/pydantic/issues/11557

Manual workaround is:
```
./start_environment.sh
pip uninstall pydantic
pip uninstall pydantic_core
pip install pydantic=2.10.6
exit
```

I tested this change with standalone and modified the other requirements files that include pydantic, but haven't tested them.

I'm not sure if it's worth pinning this now and remembering to loosen it up after pydantic has fixed the bug, or just wait it out. But it has generated a few issues: #574 #579 #580 