### PR TITLE
Fix: Corrected conditional check in docker-start.sh for port mapping

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -79,7 +79,7 @@ if [[ -n $RVC_VOICES ]]; then
   DOCKER_ARGS+=( -v ${RVC_VOICES}:${ALLTALK_DIR}/models/rvc_voices )
 fi
 
-if [ "ALLTALK_GRADIO_INTERFACE" = true ] ; then
+if [ "$ALLTALK_GRADIO_INTERFACE" = true ] ; then
     if [ "$ALLTALK_ENABLE_MULTI_ENGINE_MANAGER" = true ] ; then
       DOCKER_ARGS+=( -p 7500:7500 )
     else


### PR DESCRIPTION
This PR fixes a bug in `docker-start.sh` that prevented the Gradio interface (port 7852) from being correctly mapped to the host.

**Problem:**
The conditional checks for `ALLTALK_GRADIO_INTERFACE`were incorrectly comparing string literals instead of variable values (e.g., `[ "ALLTALK_GRADIO_INTERFACE" = true ]` instead of `[ "$ALLTALK_GRADIO_INTERFACE" = true ]`). This caused the `-p 7852:7852` argument to not be added to the `docker run` comman .

**Solution:**
Changed the conditional checks to correctly reference the shell variables by adding `$` (dollar sign) before the variable names.
- `if [ "$ALLTALK_GRADIO_INTERFACE" = true ]`


This ensures that the Gradio port 7852 (or 7500 for multi-engine manager) is correctly mapped, allowing external access to the web UI.