### PR TITLE
Make free disk space to also consider large packages and swap storage

### DIFF
--- a/.github/actions/docker-setup/action.yml
+++ b/.github/actions/docker-setup/action.yml
@@ -18,8 +18,8 @@ runs:
       uses: jlumbroso/free-disk-space@v1.3.1
       with:
         tool-cache: true
-        swap-storage: false
-        large-packages: false
+        swap-storage: true
+        large-packages: true
     - name: Read variables
       shell: bash
       run: |


### PR DESCRIPTION
The following run https://github.com/erew123/alltalk_tts/actions/runs/20846020005/job/59889923374 resulted in this error:

ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device

Therefore increasing disk space cleanup measures.